### PR TITLE
 feat: set -euo pipefail and cleanup excess output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,3 +81,10 @@ jar {
         into "lib/"
     }
 }
+
+/*
+> Task :jar
+Execution optimizations have been disabled for task ':jar' to ensure correctness due to the following reasons:
+  - Gradle detected a problem with the following location: '/Users/josh/dev/script-executor-task/build/license/THIRD-PARTY-NOTICES.txt'. Reason: Task ':jar' uses this output of task ':generateLicenseReport' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
+*/
+tasks.named("jar").configure { dependsOn("generateLicenseReport") }

--- a/src/main/java/com/tw/go/plugin/task/GoPluginImpl.java
+++ b/src/main/java/com/tw/go/plugin/task/GoPluginImpl.java
@@ -176,7 +176,7 @@ public class GoPluginImpl implements GoPlugin {
             return executeCommand(workingDirectory, environmentVariables, "cmd", "/c", scriptFileName);
         }
         String shCmd = "/bin/" + shType;
-        return executeCommand(workingDirectory, environmentVariables, shCmd, "-c", "./" + scriptFileName);
+        return executeCommand(workingDirectory, environmentVariables, shCmd, "-euo", "pipefail", "-c", "./" + scriptFileName);
     }
 
     private int executeCommand(String workingDirectory, Map<String, String> environmentVariables, String... command) throws IOException, InterruptedException {

--- a/src/main/java/com/tw/go/plugin/task/GoPluginImpl.java
+++ b/src/main/java/com/tw/go/plugin/task/GoPluginImpl.java
@@ -118,16 +118,12 @@ public class GoPluginImpl implements GoPlugin {
 
             Map<String, String> scriptConfig = (Map<String, String>) configKeyValuePairs.get("script");
             String scriptValue = scriptConfig.get("value");
-            JobConsoleLogger.getConsoleLogger().printLine("[script-executor] Script: \n ");
-            JobConsoleLogger.getConsoleLogger().printLine("[script-executor] -------------------------");
             JobConsoleLogger.getConsoleLogger().printLine(scriptValue);
-            JobConsoleLogger.getConsoleLogger().printLine("[script-executor] -------------------------");
             Map<String, String> shTypeConfig = (Map<String, String>) configKeyValuePairs.get("shtype");
             String shType = shTypeConfig.get("value");
             if (shType == null || shType.trim().equals("")) {
                 shType = "bash";
             }
-            JobConsoleLogger.getConsoleLogger().printLine("[script-executor] Script Type: " + shType);
 
             scriptFileName = generateScriptFileName(isWindows);
 
@@ -153,7 +149,6 @@ public class GoPluginImpl implements GoPlugin {
     private boolean isWindows() {
         String osName = System.getProperty("os.name");
         boolean isWindows = osName.toLowerCase().contains("windows");
-        JobConsoleLogger.getConsoleLogger().printLine("[script-executor] OS detected: '" + osName + "'. Is Windows? " + isWindows);
         return isWindows;
     }
 
@@ -169,11 +164,7 @@ public class GoPluginImpl implements GoPlugin {
         Path scriptPath = getScriptPath(workingDirectory, scriptFileName);
         Files.writeString(scriptPath, cleanupScript(scriptValue), StandardCharsets.UTF_8);
 
-        if (!isWindows) {
-            executeCommand(workingDirectory, null, "chmod", "u+x", scriptFileName);
-        }
-
-        JobConsoleLogger.getConsoleLogger().printLine("[script-executor] Script written into '" + scriptPath.toAbsolutePath() + "'.");
+        executeCommand(workingDirectory, null, "chmod", "u+x", scriptFileName);
     }
 
     String cleanupScript(String scriptValue) {


### PR DESCRIPTION
I found out this doesn't even set -e... lol.

Also, removes the excess logging that we don't really need, and windows stuff. I like to think this'll make executing scripts 10000000000x faster.