### PR TITLE
fix: stop using -c

### DIFF
--- a/src/main/java/com/tw/go/plugin/task/GoPluginImpl.java
+++ b/src/main/java/com/tw/go/plugin/task/GoPluginImpl.java
@@ -161,7 +161,7 @@ public class GoPluginImpl implements GoPlugin {
     }
 
     private int executeScript(String workingDirectory, String shType, String scriptFileName, Map<String, String> environmentVariables) throws IOException, InterruptedException {
-        return executeCommand(workingDirectory, environmentVariables, "/bin/bash", "-euo", "pipefail", "-c", "./" + scriptFileName);
+        return executeCommand(workingDirectory, environmentVariables, "/bin/bash", "-euo", "pipefail", scriptFileName);
     }
 
     private int executeCommand(String workingDirectory, Map<String, String> environmentVariables, String... command) throws IOException, InterruptedException {


### PR DESCRIPTION
Should have tested in local dev just to be sure... thought this was a fairly obvious fix but turns out `-euo pipefail` has no effect under `-c`. Just stop using it and execute the script directly.

```
echo a
echo b | false
echo unreachable
```

With `-c ./script`: 
```
a
unreachable
```

With `./script`:
```
a
```
